### PR TITLE
Fix no handling of empty string response

### DIFF
--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -180,8 +180,9 @@ class DnsMadeEasy
     end
 
     response = http.request(request)
+    unparsed_json = response.body == "" ? "{}" : response.body
 
-    JSON.parse(response.body)
+    JSON.parse(unparsed_json)
   end
 
   def request_headers

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -245,4 +245,11 @@ describe DnsMadeEasy do
       expect(subject.update_record('something.wanelo.com', 21, 'mail', 'A', '1.1.1.1', options = {})).to eq({})
     end
   end
+
+  describe "#request" do
+    it "handles an empty string response" do
+      Net::HTTP.any_instance.stub(:request).and_return(double(body: ""))
+      expect(subject.send(:request, "/some_path") { {} }).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
Making a request to certain endpoints doesn't return JSON, but we still attempt to parse all responses as JSON. This results in parse failures, specifically for the delete_record method which returns a 200 with an empty string as content.
