### PR TITLE
Allow user to find domain record, instead of just id

### DIFF
--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -58,6 +58,11 @@ class DnsMadeEasy
     get "/dns/managed/#{get_id_by_domain(domain_name)}/records"
   end
 
+  def find(domain_name, name, type)
+    records = records_for(domain_name)
+    records['data'].detect { |r| r['name'] == name && r['type'] == type }
+  end
+
   def find_record_id(domain_name, name, type)
     records = records_for(domain_name)
 

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -111,6 +111,25 @@ describe DnsMadeEasy do
     end
   end
 
+  describe '#find' do
+    let(:records_for_response) do
+      {
+        'data' => [
+          { 'name' => 'demo', 'type' => 'A', 'id' => 123},
+          { 'name' => 'demo', 'type' => 'A', 'id' => 143}
+        ]
+      }
+    end
+
+    before do
+      subject.stub(:records_for).with('something.wanelo.com').and_return(records_for_response)
+    end
+
+    it 'finds the first record that matches name and type' do
+      expect(subject.find('something.wanelo.com', 'demo', 'A')).to eq({ 'name' => 'demo', 'type' => 'A', 'id' => 123})
+    end
+  end
+
   describe '#find_record_id' do
     let(:records_for_response) do
       {


### PR DESCRIPTION
When we need to look at the actual data in the API response (for instance when checking whether the current data equals the expected data), we need more than just `#find_record_id`. We don't want to keep hitting the Rest API over and over and over again, so thought it would be helpful to provide a new public method.
