### PR TITLE
Handle non-2xx responses more gracefully

### DIFF
--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -185,7 +185,9 @@ class DnsMadeEasy
     end
 
     response = http.request(request)
-    unparsed_json = response.body == "" ? "{}" : response.body
+    response.value # raise Net::HTTPServerException unless response was 2xx
+
+    unparsed_json = response.body.to_s.empty? ? "{}" : response.body
 
     JSON.parse(unparsed_json)
   end


### PR DESCRIPTION
The API seems to return an HTML response for errors instead of a JSON representation of the error message. This results in a `JSON::ParserError` given the existing code, so this changes it to explicitly have the response object raise an `HTTPServerError` if it's an unsuccessful response type. Consumers of this gem can handle those errors with more grace than a generic parser error.