### PR TITLE
Stop delete_records from deleting all records on the domain

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dnsmadeeasy-rest-api (1.0.1)
+    dnsmadeeasy-rest-api (1.0.3)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ api.delete_record('hello.example.com', 123)
 # To delete multiple records:
 
 api.delete_records('hello.example.com', [123, 143])
+
+# To delete all records in the domain:
+
+api.delete_all_records('hello.example.com')
 ```
 
 To create a record:

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -70,14 +70,20 @@ class DnsMadeEasy
                    .map    { |r| r['id'] }
   end
 
-  def delete_records(domain_name, ids = [])
-    id = get_id_by_domain(domain_name)
-
-    delete "/dns/managed/#{id}/records/", ids
-  end
-
   def delete_record(domain_name, record_id)
     delete "/dns/managed/#{get_id_by_domain(domain_name)}/records/#{record_id}/"
+  end
+
+  def delete_records(domain_name, ids = [])
+    return if ids.empty?
+    domain_id = get_id_by_domain(domain_name)
+
+    delete "/dns/managed/#{domain_id}/records?ids=#{ids.join(',')}"
+  end
+
+  def delete_all_records(domain_name)
+    domain_id = get_id_by_domain(domain_name)
+    delete "/dns/managed/#{domain_id}/records"
   end
 
   def create_record(domain_name, name, type, value, options = {})
@@ -144,13 +150,13 @@ class DnsMadeEasy
 
   def get(path)
     request(path) do |uri|
-      Net::HTTP::Get.new(uri.path)
+      Net::HTTP::Get.new(uri)
     end
   end
 
   def delete(path, body = nil)
     request(path) do |uri|
-      req = Net::HTTP::Delete.new(uri.path)
+      req = Net::HTTP::Delete.new(uri)
       req.body = body.to_json if body
       req
     end
@@ -158,7 +164,7 @@ class DnsMadeEasy
 
   def put(path, body = nil)
     request(path) do |uri|
-      req = Net::HTTP::Put.new(uri.path)
+      req = Net::HTTP::Put.new(uri)
       req.body = body.to_json if body
       req
     end
@@ -166,7 +172,7 @@ class DnsMadeEasy
 
   def post(path, body)
     request(path) do |uri|
-      req = Net::HTTP::Post.new(uri.path)
+      req = Net::HTTP::Post.new(uri)
       req.body = body.to_json
       req
     end

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -261,7 +261,7 @@ describe DnsMadeEasy do
         to_return(:status => 200, :body => response, :headers => {})
 
 
-      expect(subject.update_record('something.wanelo.com', 21, 'mail', 'A', '1.1.1.1', options = {})).to eq({})
+      expect(subject.update_record('something.wanelo.com', 21, 'mail', 'A', '1.1.1.1', {})).to eq({})
     end
   end
 

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -151,17 +151,47 @@ describe DnsMadeEasy do
 
   describe '#delete_records' do
     let(:response) { "{}" }
+    let(:domain) { 'something.wanelo.com' }
+    let(:domain_id) { 123 }
 
-    before do
-      subject.stub(:get_id_by_domain).with('something.wanelo.com').and_return(123)
+    context 'with an array of record ids' do
+      let(:ids) { [147, 159] }
+
+      before do
+        subject.stub(:get_id_by_domain).with(domain).and_return(domain_id)
+
+        stub_request(:delete, "https://api.dnsmadeeasy.com/V2.0/dns/managed/#{domain_id}/records?ids=#{ids.join(',')}").
+          with(headers: request_headers).
+          to_return(:status => 200, :body => response, :headers => {})
+      end
+
+      it 'deletes a list of records from a given domain' do
+        expect(subject.delete_records('something.wanelo.com', ids)).to eq({})
+      end
     end
 
-    it 'deletes a list of records from a given domain' do
-      stub_request(:delete, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records/").
-        with(headers: request_headers, body: "[147,159]").
-        to_return(:status => 200, :body => response, :headers => {})
+    context 'with an empty array' do
+      it 'returns early without deleting anything' do
+        expect(subject.delete_records('something.wanelo.com', [])).to eq(nil)
+      end
+    end
+  end
 
-      expect(subject.delete_records('something.wanelo.com', [147, 159])).to eq({})
+  describe '#delete_all_records' do
+    let(:response) { "{}" }
+    let(:domain) { 'something.wanelo.com' }
+    let(:domain_id) { 123 }
+
+    before do
+      subject.stub(:get_id_by_domain).with(domain).and_return(domain_id)
+
+      stub_request(:delete, "https://api.dnsmadeeasy.com/V2.0/dns/managed/#{domain_id}/records").
+        with(headers: request_headers).
+        to_return(:status => 200, :body => response, :headers => {})
+    end
+
+    it 'deletes all records from the domain' do
+      expect(subject.delete_all_records('something.wanelo.com')).to eq({})
     end
   end
 


### PR DESCRIPTION
See #7 for explanation.

Note that this totally changes the current behavior of `delete_records` but I'm proposing that's completely okay due to how broken it was. Still, it may be good to bump the major version to indicate this.