### PR TITLE
http verify_none support

### DIFF
--- a/dnsmadeeasy-rest-api.gemspec
+++ b/dnsmadeeasy-rest-api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'dnsmadeeasy-rest-api'
-  s.version       = '1.0.3'
+  s.version       = '1.0.4'
   s.authors       = ['Arnoud Vermeer', 'Paul Henry', 'James Hart']
   s.email         = ['a.vermeer@freshway.biz', 'ops@wanelo.com']
   s.license       = 'Apache'

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -180,7 +180,8 @@ class DnsMadeEasy
     http.use_ssl = true
     http.open_timeout = @options[:open_timeout] if @options.key?(:open_timeout)
     http.read_timeout = @options[:read_timeout] if @options.key?(:read_timeout)
-
+    http.verify_mode = @options[:verify_mode] if @options.key?(:verify_mode)
+    
     request = yield(uri)
 
     request_headers.each do |key, value|


### PR DESCRIPTION
Support for http.verify_none, for expired certificates like api.sandbox.dnsmadeeasy.com