### PR TITLE
Add the update_records method using the updateMulti endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ To update a record:
 api.update_record('hello.example.com', 123, 'woah', 'A', '127.0.1.1', { 'ttl' => '60' })
 ```
 
+To update several records:
+
+```ruby
+api.update_records('hello.example.com', [{'id'=>123, 'name'=>'buddy', 'type'=>'A','value'=>'127.0.0.1'}], { 'ttl' => '60' })
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -146,6 +146,20 @@ class DnsMadeEasy
     put "/dns/managed/#{get_id_by_domain(domain)}/records/#{record_id}/", body.merge(options)
   end
 
+  def update_records(domain, records, options = {})
+    body = records.map do |record|
+      {
+        'id' => record['id'],
+        'name' => record['name'],
+        'type' => record['type'],
+        'value' => record['value'],
+        'gtdLocation' => record['gtdLocation'],
+        'ttl' => record['ttl']
+      }.merge(options)
+    end
+    put "/dns/managed/#{get_id_by_domain(domain)}/records/updateMulti/", body
+  end
+
   private
 
   def get(path)

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -14,7 +14,7 @@ describe DnsMadeEasy do
   subject { DnsMadeEasy.new(api_key, secret_key) }
 
   before do
-    Time.stub(:now).and_return(Time.parse('Wed, 21 May 2014 18:08:37 GMT'))
+    allow(Time).to receive(:now).and_return(Time.parse('Wed, 21 May 2014 18:08:37 GMT'))
   end
 
   describe '#get_id_by_domain' do
@@ -292,6 +292,45 @@ describe DnsMadeEasy do
 
 
       expect(subject.update_record('something.wanelo.com', 21, 'mail', 'A', '1.1.1.1', {})).to eq({})
+    end
+  end
+
+  describe '#update_records' do
+    let(:response) { '{}' }
+
+    before do
+      subject.stub(:get_id_by_domain).with('something.wanelo.com').and_return(123)
+    end
+
+    it 'updates a record' do
+      records = [
+        {
+          'id' => 21,
+          'name' => 'mail',
+          'type' => 'A',
+          'value' => '1.1.1.1',
+          'gtdLocation' => 'DEFAULT',
+          'ttl' => 300
+        },
+        {
+          'id' => 22,
+          'name' => 'post',
+          'type' => 'A',
+          'value' => '1.1.1.2',
+          'gtdLocation' => 'DEFAULT',
+          'ttl' => 300
+        }
+      ]
+
+      body = '[{"id":21,"name":"mail","type":"A","value":"1.1.1.1","gtdLocation":"DEFAULT","ttl":3600},{"id":22,"name":"post","type":"A","value":"1.1.1.2","gtdLocation":"DEFAULT","ttl":3600}]'
+
+
+      stub_request(:put, "https://api.dnsmadeeasy.com/V2.0/dns/managed/123/records/updateMulti/").
+        with(headers: request_headers, body: body).
+        to_return(status: 200, body: response, headers: {})
+
+
+      expect(subject.update_records('something.wanelo.com', records, { 'ttl' => 3600 })).to eq({})
     end
   end
 


### PR DESCRIPTION
Instead of using up the requests per 5 minutes quota, a new method that
will update several records for a domain at once would be a useful
addition.

So with that the method `update_records` came to be, it is using the
`updateMulti` endpoint, that is described in the api documentation.

It requires an array of records that contains the future values set to the
respective keys. This only applies to `name`,
`type` and `value` as these were the ones that seemed the most useful
ones.

The options hash is applied to all records in the update.

The records would look something like the following:

```rb
[
  {
    "id"=>"123",
    "name"=>"foo",
    "type"=>"A",
    "value"=>"127.0.0.1",
    "gtdLocation"=>"DEFAULT",
    "ttl"=>"300"
  },
  ....
]
```

method signature:

```rb
update_records('domain name', [array of records], {options})
```