### PR TITLE
1.0.5

### DIFF
--- a/dnsmadeeasy-rest-api.gemspec
+++ b/dnsmadeeasy-rest-api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'dnsmadeeasy-rest-api'
-  s.version       = '1.0.4'
+  s.version       = '1.0.5'
   s.authors       = ['Arnoud Vermeer', 'Paul Henry', 'James Hart']
   s.email         = ['a.vermeer@freshway.biz', 'ops@wanelo.com']
   s.license       = 'Apache'

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -183,6 +183,7 @@ class DnsMadeEasy
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @options.key?(:ssl_verify_none)
     http.open_timeout = @options[:open_timeout] if @options.key?(:open_timeout)
     http.read_timeout = @options[:read_timeout] if @options.key?(:read_timeout)
 

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -17,7 +17,7 @@ class DnsMadeEasy
     @options = options
 
     if sandbox
-      self.base_uri = 'https://api.sandbox.dnsmadeeasy.com/V2.0'
+      self.base_uri = 'https://sandboxapi.dnsmadeeasy.com/V2.0'
     else
       self.base_uri = 'https://api.dnsmadeeasy.com/V2.0'
     end


### PR DESCRIPTION
* update the sandbox URL so that SSL works.

At the time of this PR, the sandbox api for dnsmadeeasy is using the wrong SSL certificate:
```
 openssl s_client -connect api.sandbox.dnsmadeeasy.com:443 | openssl x509 -text 2>&1 | grep -A2 'Subject Alt'

            X509v3 Subject Alternative Name:
                DNS:*.dnsmadeeasy.com, DNS:dnsmadeeasy.com
```
so it has become necessary to ignore the ssl failures while doing sandbox testing until they are able to resolve the issue.  (https://support.dnsmadeeasy.com/index.php?/Tickets/Ticket/View/DFV-388-65290)

Signed-off-by: Jake Plimack <jake.plimack@gmail.com>