### PR TITLE
Implement the failover (monitor) calls provided by API v2

### DIFF
--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -172,7 +172,7 @@ class DnsMadeEasy
     get "/monitor/#{record_id}"
   end
 
-  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=5, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
+  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=3, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
     protocolIds = {
       'TCP' => 1,
       'UDP' => 2,
@@ -203,6 +203,10 @@ class DnsMadeEasy
     body = body.merge(ip_config)
 
     put "/monitor/#{record_id}", body
+  end
+
+  def disable_failover(record_id)
+    put "/monitor/#{record_id}", { 'failover' => false, 'monitor' => false }
   end
 
   private

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -203,7 +203,6 @@ class DnsMadeEasy
 
     body = body.merge(ip_config)
 
-    puts body.inspect
     put "/monitor/#{record_id}", body
   end
 

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -164,6 +164,47 @@ class DnsMadeEasy
     put "/dns/managed/#{get_id_by_domain(domain)}/records/updateMulti/", body
   end
 
+  # -----------------------------------
+  # ------------- FAILOVER -------------
+  # -----------------------------------
+
+  def get_failover_config(record_id)
+    get "/monitor/#{record_id}"
+  end
+
+  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=5, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
+    protocolIds = {
+      'TCP' => 1,
+      'UDP' => 2,
+      'HTTP' => 3,
+      'DNS' => 4,
+      'HTTPS' => 6
+    }
+
+    body = {
+      'port' => port,
+      'protocolId' => protocolIds[protocol],
+      'systemDescription' => desc,
+      'sensitivity' => sensitivity,
+      'failover' => failover,
+      'monitor' => monitor,
+      'maxEmails' => max_emails,
+      'autoFailover' => auto_failover,
+      'source' => source
+    }
+
+    body = body.merge(custom_monitor_config)
+
+    ip_config = {}
+    (0.. ips.length-1).each do |idx|
+      ip_config["ip#{idx+1}"] = ips[idx]
+    end
+
+    body = body.merge(ip_config)
+
+    put "/monitor/#{record_id}", body
+  end
+
   private
 
   def get(path)

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -172,28 +172,29 @@ class DnsMadeEasy
     get "/monitor/#{record_id}"
   end
 
-  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=3, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
+  def update_failover_config(record_id, ips, desc, protocol='TCP', options = {})
     protocolIds = {
       'TCP' => 1,
       'UDP' => 2,
       'HTTP' => 3,
       'DNS' => 4,
+      'SMTP' => 5,
       'HTTPS' => 6
     }
 
     body = {
-      'port' => port,
       'protocolId' => protocolIds[protocol],
+      'port' => 80,
       'systemDescription' => desc,
-      'sensitivity' => sensitivity,
-      'failover' => failover,
-      'monitor' => monitor,
-      'maxEmails' => max_emails,
-      'autoFailover' => auto_failover,
-      'source' => source
+      'sensitivity' => 5,
+      'failover' => true,
+      'monitor' => false,
+      'maxEmails' => 1,
+      'autoFailover' => false,
+      'source' => 1
     }
 
-    body = body.merge(custom_monitor_config)
+    body = body.merge(options)
 
     ip_config = {}
     (0.. ips.length-1).each do |idx|
@@ -202,6 +203,7 @@ class DnsMadeEasy
 
     body = body.merge(ip_config)
 
+    puts body.inspect
     put "/monitor/#{record_id}", body
   end
 


### PR DESCRIPTION
The simple fetch, update and disable calls on the monitor are implemented, trying to be consistent with the rest of the code. The only major deviation is making the monitored protocol human readable.