### PR TITLE
Implement the failover (monitor) calls provided by API v2

### DIFF
--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -172,7 +172,7 @@ class DnsMadeEasy
     get "/monitor/#{record_id}"
   end
 
-  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=5, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
+  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=3, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
     protocolIds = {
       'TCP' => 1,
       'UDP' => 2,
@@ -203,6 +203,10 @@ class DnsMadeEasy
     body = body.merge(ip_config)
 
     put "/monitor/#{record_id}", body
+  end
+
+  def disable_failover(record_id)
+    put "/monitor/#{record_id}", { 'failover' => false, 'monitor' => false }
   end
 
   private

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -203,7 +203,6 @@ class DnsMadeEasy
 
     body = body.merge(ip_config)
 
-    puts body.inspect
     put "/monitor/#{record_id}", body
   end
 

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -164,6 +164,47 @@ class DnsMadeEasy
     put "/dns/managed/#{get_id_by_domain(domain)}/records/updateMulti/", body
   end
 
+  # -----------------------------------
+  # ------------- FAILOVER -------------
+  # -----------------------------------
+
+  def get_failover_config(record_id)
+    get "/monitor/#{record_id}"
+  end
+
+  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=5, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
+    protocolIds = {
+      'TCP' => 1,
+      'UDP' => 2,
+      'HTTP' => 3,
+      'DNS' => 4,
+      'HTTPS' => 6
+    }
+
+    body = {
+      'port' => port,
+      'protocolId' => protocolIds[protocol],
+      'systemDescription' => desc,
+      'sensitivity' => sensitivity,
+      'failover' => failover,
+      'monitor' => monitor,
+      'maxEmails' => max_emails,
+      'autoFailover' => auto_failover,
+      'source' => source
+    }
+
+    body = body.merge(custom_monitor_config)
+
+    ip_config = {}
+    (0.. ips.length-1).each do |idx|
+      ip_config["ip#{idx+1}"] = ips[idx]
+    end
+
+    body = body.merge(ip_config)
+
+    put "/monitor/#{record_id}", body
+  end
+
   private
 
   def get(path)

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -172,28 +172,29 @@ class DnsMadeEasy
     get "/monitor/#{record_id}"
   end
 
-  def update_failover_config(record_id, ips, desc, port=80, protocol='TCP', custom_monitor_config = {}, sensitivity=3, failover=true, auto_failover=false, monitor=false, max_emails=1, source=1)
+  def update_failover_config(record_id, ips, desc, protocol='TCP', options = {})
     protocolIds = {
       'TCP' => 1,
       'UDP' => 2,
       'HTTP' => 3,
       'DNS' => 4,
+      'SMTP' => 5,
       'HTTPS' => 6
     }
 
     body = {
-      'port' => port,
       'protocolId' => protocolIds[protocol],
+      'port' => 80,
       'systemDescription' => desc,
-      'sensitivity' => sensitivity,
-      'failover' => failover,
-      'monitor' => monitor,
-      'maxEmails' => max_emails,
-      'autoFailover' => auto_failover,
-      'source' => source
+      'sensitivity' => 5,
+      'failover' => true,
+      'monitor' => false,
+      'maxEmails' => 1,
+      'autoFailover' => false,
+      'source' => 1
     }
 
-    body = body.merge(custom_monitor_config)
+    body = body.merge(options)
 
     ip_config = {}
     (0.. ips.length-1).each do |idx|
@@ -202,6 +203,7 @@ class DnsMadeEasy
 
     body = body.merge(ip_config)
 
+    puts body.inspect
     put "/monitor/#{record_id}", body
   end
 

--- a/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
+++ b/spec/lib/dnsmadeeasyapi-rest-api_spec.rb
@@ -334,6 +334,92 @@ describe DnsMadeEasy do
     end
   end
 
+  describe '#get_failover_config' do
+    let(:response) do
+      '{
+      "port":80,
+      "source":1,
+      "failover":true,
+      "ip1":"1.1.1.1",
+      "ip2":"2.2.2.2",
+      "protocolId":3,
+      "sourceId":104620,
+      "monitor":true,
+      "sensitivity":5,
+      "systemDescription":"Test",
+      "maxEmails":1,
+      "ip1Failed":0,
+      "ip2Failed":0,
+      "ip3Failed":0,
+      "ip4Failed":0,
+      "ip5Failed":0,
+      "recordId":21,
+      "autoFailover":false
+      }'
+    end
+
+    it 'gets the failover config for a failover enabled record' do
+      stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/monitor/21").
+        with(headers: request_headers).
+        to_return(status: 200, body: response, headers: {})
+
+      expect(subject.get_failover_config(21)).to eq({
+        'port' => 80,
+        'source' => 1,
+        'failover' => true,
+        'ip1' => '1.1.1.1',
+        'ip2' => '2.2.2.2',
+        'protocolId' => 3,
+        'sourceId' => 104620,
+        'monitor' => true,
+        'sensitivity' => 5,
+        'systemDescription' => 'Test',
+        'maxEmails' => 1,
+        'ip1Failed' => 0,
+        'ip2Failed' => 0,
+        'ip3Failed' => 0,
+        'ip4Failed' => 0,
+        'ip5Failed' => 0,
+        'recordId' => 21,
+        'autoFailover' => false
+        })
+    end
+  end
+
+  describe '#disable_failover' do
+    let(:response) { "{}" }
+    let(:body) { '{"failover":false,"monitor":false}' }
+
+    it 'disables the failover config for a failover enabled record' do
+      stub_request(:put, "https://api.dnsmadeeasy.com/V2.0/monitor/21").
+        with(headers: request_headers, body: body).
+        to_return(status: 200, body: response, headers: {})
+
+      expect(subject.disable_failover(21)).to eq({})
+    end
+  end
+
+  describe '#update_failover_config' do
+    let(:response) { "{}" }
+    let(:body) do
+      '{"protocolId":3,"port":80,"systemDescription":"Test","sensitivity":3,"failover":true,"monitor":false,"maxEmails":1,"autoFailover":false,"source":1,"httpFqdn":"example.com","httpFile":"/magic","httpQueryString":"more-magic","ip1":"1.1.1.1","ip2":"2.2.2.2"}'
+    end
+
+    it "updates the failover config" do
+      stub_request(:put, "https://api.dnsmadeeasy.com/V2.0/monitor/21").
+        with(headers: request_headers, body: body).
+        to_return(status: 200, body: response, headers: {})
+
+      expect(subject.update_failover_config(21, ['1.1.1.1', '2.2.2.2'], 'Test', 'HTTP', {
+        'port' => 80,
+        'httpFqdn' => 'example.com',
+        'httpFile' => '/magic',
+        'httpQueryString' => 'more-magic',
+        'sensitivity' => 3
+      })).to eq({})
+    end
+  end
+
   describe "#request" do
     before do
       stub_request(:get, "https://api.dnsmadeeasy.com/V2.0/some_path").


### PR DESCRIPTION
The simple fetch, update and disable calls on the monitor are implemented, trying to be consistent with the rest of the code. The only major deviation is making the monitored protocol human readable.