### PR TITLE
Update sandbox URL and document options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Start by creating a new instance of the `DnsMadeEasy` class, and passing your ap
 api = DnsMadeEasy.new('awesome-api-key', 'super-secret-and-awesome-api-secret')
 ```
 
+Optionally, you can connect to the sandbox API if you want to play around.
+
+```ruby
+api = DnsMadeEasy.new('awesome-api-key', 'super-secret-and-awesome-api-secret', sandbox=TRUE)
+```
+
 All return values are the direct JSON responses from DNS Made Easy converted into a Hash.
 
 See: [https://api-docs.dnsmadeeasy.com/](https://api-docs.dnsmadeeasy.com/)

--- a/lib/dnsmadeeasy-rest-api.rb
+++ b/lib/dnsmadeeasy-rest-api.rb
@@ -21,7 +21,7 @@ class DnsMadeEasy
     @request_limit = -1
 
     if sandbox
-      self.base_uri = 'https://sandboxapi.dnsmadeeasy.com/V2.0'
+      self.base_uri = 'https://api.sandbox.dnsmadeeasy.com/V2.0'
     else
       self.base_uri = 'https://api.dnsmadeeasy.com/V2.0'
     end


### PR DESCRIPTION
The correct path, according to docs, to sandbox API is
https://api.sandbox.dnsmadeeasy.com/V2.0/

The old URL still works, but ssl-certificate is not valid for that CN.
Using :ssl_verify_none option works, but should not be necessary.
Update README file with example of how to enable sandbox.